### PR TITLE
Implement Pydantic + SQLAlchemy Models (#2)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -1,6 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 
 from .config import settings
+from .models import Base  # Import Base to create tables
 
 engine = create_async_engine(settings.database_url, echo=True)
 
@@ -13,6 +14,5 @@ async def get_db() -> AsyncSession:
 
 
 async def create_tables():
-    # This will be called after models are defined
-    # For now, placeholder
-    pass
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,11 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+from .hn import HNItem
+from .trend import Trend
+from .tweet import Tweet
+from .user_content import UserContent

--- a/src/models/hn.py
+++ b/src/models/hn.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+from sqlalchemy import Column, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class HNItemPydantic(BaseModel):
+    id: int
+    title: str
+    url: Optional[str] = None
+    text: Optional[str] = None
+    created_at: datetime
+    author: str
+    points: int
+
+
+class HNItem(Base):
+    __tablename__ = "hn_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    url: Mapped[Optional[str]] = mapped_column(String)
+    text: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    author: Mapped[str] = mapped_column(String, nullable=False)
+    points: Mapped[int] = mapped_column(Integer, default=0)
+
+    def to_pydantic(self) -> HNItemPydantic:
+        return HNItemPydantic(
+            id=self.id,
+            title=self.title,
+            url=self.url,
+            text=self.text,
+            created_at=self.created_at,
+            author=self.author,
+            points=self.points,
+        )
+
+    @classmethod
+    def from_pydantic(cls, pydantic_item: HNItemPydantic) -> "HNItem":
+        return cls(
+            id=pydantic_item.id,
+            title=pydantic_item.title,
+            url=pydantic_item.url,
+            text=pydantic_item.text,
+            created_at=pydantic_item.created_at,
+            author=pydantic_item.author,
+            points=pydantic_item.points,
+        )

--- a/src/models/trend.py
+++ b/src/models/trend.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from pydantic import BaseModel
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class TrendPydantic(BaseModel):
+    name: str
+    tweet_volume: Optional[int] = None
+    woeid: int
+
+
+class Trend(Base):
+    __tablename__ = "trends"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    tweet_volume: Mapped[Optional[int]] = mapped_column(Integer)
+    woeid: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    def to_pydantic(self) -> TrendPydantic:
+        return TrendPydantic(
+            name=self.name,
+            tweet_volume=self.tweet_volume,
+            woeid=self.woeid,
+        )
+
+    @classmethod
+    def from_pydantic(cls, pydantic_trend: TrendPydantic) -> "Trend":
+        return cls(
+            name=pydantic_trend.name,
+            tweet_volume=pydantic_trend.tweet_volume,
+            woeid=pydantic_trend.woeid,
+        )

--- a/src/models/tweet.py
+++ b/src/models/tweet.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+from pydantic import BaseModel
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class TweetPydantic(BaseModel):
+    text: str
+    thread_position: int = 0
+    thread_id: Optional[str] = None
+    status: str = "pending"  # pending, posted, failed
+
+
+class Tweet(Base):
+    __tablename__ = "tweets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    thread_position: Mapped[int] = mapped_column(Integer, default=0)
+    thread_id: Mapped[Optional[str]] = mapped_column(String)
+    status: Mapped[str] = mapped_column(String, default="pending")
+
+    def to_pydantic(self) -> TweetPydantic:
+        return TweetPydantic(
+            text=self.text,
+            thread_position=self.thread_position,
+            thread_id=self.thread_id,
+            status=self.status,
+        )
+
+    @classmethod
+    def from_pydantic(cls, pydantic_tweet: TweetPydantic) -> "Tweet":
+        return cls(
+            text=pydantic_tweet.text,
+            thread_position=pydantic_tweet.thread_position,
+            thread_id=pydantic_tweet.thread_id,
+            status=pydantic_tweet.status,
+        )

--- a/src/models/user_content.py
+++ b/src/models/user_content.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+from pydantic import BaseModel
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class UserContentPydantic(BaseModel):
+    source: str  # e.g., "blog", "github"
+    url: str
+    title: Optional[str] = None
+    content: str
+    summary: Optional[str] = None
+
+
+class UserContent(Base):
+    __tablename__ = "user_content"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    url: Mapped[str] = mapped_column(String, nullable=False)
+    title: Mapped[Optional[str]] = mapped_column(String)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    summary: Mapped[Optional[str]] = mapped_column(Text)
+
+    def to_pydantic(self) -> UserContentPydantic:
+        return UserContentPydantic(
+            source=self.source,
+            url=self.url,
+            title=self.title,
+            content=self.content,
+            summary=self.summary,
+        )
+
+    @classmethod
+    def from_pydantic(cls, pydantic_content: UserContentPydantic) -> "UserContent":
+        return cls(
+            source=pydantic_content.source,
+            url=pydantic_content.url,
+            title=pydantic_content.title,
+            content=pydantic_content.content,
+            summary=pydantic_content.summary,
+        )


### PR DESCRIPTION
Implements Issue #2: Defines hybrid Pydantic + SQLAlchemy models for HNItem, Trend, Tweet (with thread support), and UserContent.

- Pydantic models for validation/API use
- SQLAlchemy tables for DB persistence
- Conversion methods between Pydantic and DB objects
- Updated database.py to create tables asynchronously
- Tested: imports work, tables created successfully

Ready for review and merge to enable data persistence.