### PR TITLE
Fix PostingAgent to Use PydanticAI Agent with Tools

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,8 +39,9 @@ async def run_bot_cycle():
                 tweet_thread = await generate_thread(topic, opinion)
 
                 # Post thread
-                posting_agent = container.posting_agent()
-                posted_ids = await posting_agent.post_thread(tweet_thread.tweets)
+                from src.agents.posting_agent import post_thread_via_agent
+
+                posted_ids = await post_thread_via_agent(tweet_thread.tweets)
                 logger.info(f"Posted thread with IDs: {posted_ids}")
     except Exception as e:
         logger.error(f"Error in bot cycle: {e}")

--- a/src/agents/posting_agent.py
+++ b/src/agents/posting_agent.py
@@ -1,5 +1,7 @@
 from typing import List
 import tweepy
+import asyncio
+from pydantic_ai import Agent, tool
 
 from ..config import settings
 from ..database import get_db
@@ -7,46 +9,88 @@ from ..models.tweet import Tweet as DBTweet, TweetPydantic
 from .tweet_agent import Tweet
 
 
-class PostingAgent:
-    def __init__(self):
-        self.client = tweepy.Client(
-            bearer_token=settings.twitter_bearer_token,
-            consumer_key=settings.twitter_consumer_key,
-            consumer_secret=settings.twitter_consumer_secret,
-            access_token=settings.twitter_access_token,
-            access_token_secret=settings.twitter_access_token_secret,
+posting_client = tweepy.Client(
+    bearer_token=settings.twitter_bearer_token,
+    consumer_key=settings.twitter_consumer_key,
+    consumer_secret=settings.twitter_consumer_secret,
+    access_token=settings.twitter_access_token,
+    access_token_secret=settings.twitter_access_token_secret,
+)
+
+
+@tool
+async def post_initial_tweet(text: str) -> str:
+    """Post the initial tweet in a thread."""
+    try:
+        response = await asyncio.to_thread(posting_client.create_tweet, text=text)
+        tweet_id = str(response.data["id"])
+
+        # Save to DB
+        db_tweet = DBTweet.from_pydantic(
+            TweetPydantic(text=text, thread_position=0, thread_id=tweet_id, status="posted")
         )
+        async for session in get_db():
+            session.add(db_tweet)
+            await session.commit()
 
-    async def post_thread(self, thread: List[Tweet]) -> List[str]:
-        posted_ids = []
-        reply_to = None
-        for tweet in thread:
-            try:
-                response = self.client.create_tweet(text=tweet.text, in_reply_to_status_id=reply_to)
-                tweet_id = response.data["id"]
-                posted_ids.append(str(tweet_id))
-                reply_to = tweet_id
+        return f"Posted initial tweet: {tweet_id}"
+    except Exception as e:
+        # Save failed
+        db_tweet = DBTweet.from_pydantic(
+            TweetPydantic(text=text, thread_position=0, status="failed")
+        )
+        async for session in get_db():
+            session.add(db_tweet)
+            await session.commit()
+        return f"Failed to post initial tweet: {e}"
 
-                # Save to DB
-                db_tweet = DBTweet.from_pydantic(
-                    TweetPydantic(
-                        text=tweet.text,
-                        thread_position=tweet.position,
-                        thread_id=str(tweet_id) if tweet.position == 0 else None,
-                        status="posted",
-                    )
-                )
-                async for session in get_db():
-                    session.add(db_tweet)
-                    await session.commit()
-            except Exception as e:
-                print(f"Error posting tweet: {e}")
-                # Mark as failed
-                db_tweet = DBTweet.from_pydantic(
-                    TweetPydantic(text=tweet.text, thread_position=tweet.position, status="failed")
-                )
-                async for session in get_db():
-                    session.add(db_tweet)
-                    await session.commit()
-                break
-        return posted_ids
+
+@tool
+async def post_reply_tweet(text: str, reply_to_id: str) -> str:
+    """Post a reply tweet in a thread."""
+    try:
+        response = await asyncio.to_thread(
+            posting_client.create_tweet, text=text, in_reply_to_status_id=reply_to_id
+        )
+        tweet_id = str(response.data["id"])
+
+        # Save to DB
+        db_tweet = DBTweet.from_pydantic(
+            TweetPydantic(text=text, thread_position=1, thread_id=reply_to_id, status="posted")
+        )
+        async for session in get_db():
+            session.add(db_tweet)
+            await session.commit()
+
+        return f"Posted reply tweet: {tweet_id}"
+    except Exception as e:
+        # Save failed
+        db_tweet = DBTweet.from_pydantic(
+            TweetPydantic(text=text, thread_position=1, status="failed")
+        )
+        async for session in get_db():
+            session.add(db_tweet)
+            await session.commit()
+        return f"Failed to post reply tweet: {e}"
+
+
+posting_agent = Agent(
+    "openai:gpt-4o-mini",
+    system_prompt="You are a Twitter posting agent. Use tools to post tweet threads. Start with initial tweet, then reply tweets. Handle errors gracefully. Return list of posted tweet IDs.",
+    result_type=List[str],
+    tools=[post_initial_tweet, post_reply_tweet],
+)
+
+
+async def post_thread_via_agent(thread: List[Tweet]) -> List[str]:
+    """Post a thread using the PydanticAI agent."""
+    if not thread:
+        return []
+
+    # Prepare thread data
+    thread_data = "\n".join([f"Tweet {i + 1}: {tweet.text}" for i, tweet in enumerate(thread)])
+
+    prompt = f"Post this tweet thread:\n{thread_data}\nUse tools to post each tweet in sequence. Return the list of tweet IDs."
+
+    result = await posting_agent.run(prompt)
+    return result.data

--- a/src/di.py
+++ b/src/di.py
@@ -9,7 +9,7 @@ from .sources.rss_fetcher import RSSFetcher
 from .agents.research_agent import research_agent
 from .agents.opinion_agent import opinion_agent
 from .agents.tweet_agent import tweet_agent
-from .agents.posting_agent import PostingAgent
+
 from .services.scraper import ScraperService
 from .services.scheduler import SchedulerService
 
@@ -38,7 +38,6 @@ class Container(containers.DeclarativeContainer):
     research_agent_provider = providers.Object(research_agent)
     opinion_agent_provider = providers.Object(opinion_agent)
     tweet_agent_provider = providers.Object(tweet_agent)
-    posting_agent = providers.Singleton(PostingAgent)
 
     # Services
     scraper_service = providers.Singleton(ScraperService)


### PR DESCRIPTION
Fixes PostingAgent to properly use PydanticAI instead of direct SDK config.

- Replace PostingAgent class with PydanticAI Agent + tools
- Add tools: post_initial_tweet, post_reply_tweet (async with Tweepy)
- Agent orchestrates thread posting with LLM reasoning
- Update main.py to use post_thread_via_agent function
- Remove from DI since it's now functional

PostingAgent now leverages PydanticAI for intelligent posting.